### PR TITLE
Taks 1 - Refactor get_api_endpoints()

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -34,7 +34,6 @@ from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     import connexion
-    from flask import Blueprint
     from flask_appbuilder.menu import MenuItem
     from sqlalchemy.orm import Session
 
@@ -82,8 +81,8 @@ class BaseAuthManager(LoggingMixin):
         """
         return []
 
-    def set_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None | Blueprint:
-        """Return API endpoint(s) definition for the auth manager."""
+    def set_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None:
+        """Set API endpoint(s) definition for the auth manager."""
         return None
 
     def get_user_name(self) -> str:

--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -82,7 +82,7 @@ class BaseAuthManager(LoggingMixin):
         """
         return []
 
-    def get_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None | Blueprint:
+    def set_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None | Blueprint:
         """Return API endpoint(s) definition for the auth manager."""
         return None
 

--- a/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Container
 
 from connexion.options import SwaggerUIOptions
-from flask import Blueprint, url_for
+from flask import url_for
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
@@ -150,7 +150,7 @@ class FabAuthManager(BaseAuthManager):
             SYNC_PERM_COMMAND,  # not in a command group
         ]
 
-    def get_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None | Blueprint:
+    def set_api_endpoints(self, connexion_app: connexion.FlaskApp) -> None:
         folder = Path(__file__).parents[0].resolve()  # this is airflow/auth/managers/fab/
         with folder.joinpath("openapi", "v1.yaml").open() as f:
             specification = safe_load(f)
@@ -159,7 +159,7 @@ class FabAuthManager(BaseAuthManager):
             swagger_ui=conf.getboolean("webserver", "enable_swagger_ui", fallback=True),
         )
 
-        api = connexion_app.add_api(
+        connexion_app.add_api(
             specification=specification,
             resolver=_LazyResolver(),
             base_path="/auth/fab/v1",
@@ -167,7 +167,7 @@ class FabAuthManager(BaseAuthManager):
             strict_validation=True,
             validate_responses=True,
         )
-        return api.blueprint if api else None
+        return None
 
     def get_user_display_name(self) -> str:
         """Return the user's display name associated to the user in session."""

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -21,6 +21,7 @@ import warnings
 from datetime import timedelta
 
 import connexion
+from flask import request
 from flask_appbuilder import SQLA
 from flask_wtf.csrf import CSRFProtect
 from markupsafe import Markup
@@ -72,6 +73,15 @@ csrf = CSRFProtect()
 def create_app(config=None, testing=False):
     """Create a new instance of Airflow WWW app."""
     connexion_app = connexion.FlaskApp(__name__)
+
+    @connexion_app.app.before_request
+    def before_request():
+        """Exempts the view function associated with '/api/v1' requests from CSRF protection."""
+        if request.path.startswith("/api/v1"):  # TODO: make sure this path is correct
+            view_function = flask_app.view_functions.get(request.endpoint)
+            if view_function:
+                # Exempt the view function from CSRF protection
+                connexion_app.app.extensions["csrf"].exempt(view_function)
 
     connexion_app.add_middleware(
         CORSMiddleware,

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -304,8 +304,4 @@ def init_api_experimental(app):
 def init_api_auth_provider(connexion_app: connexion.FlaskApp):
     """Initialize the API offered by the auth manager."""
     auth_mgr = get_auth_manager()
-    blueprint = auth_mgr.get_api_endpoints(connexion_app)
-    if blueprint:
-        base_paths.append(blueprint.url_prefix if blueprint.url_prefix else "")
-        flask_app = connexion_app.app
-        flask_app.extensions["csrf"].exempt(blueprint)
+    auth_mgr.set_api_endpoints(connexion_app)

--- a/docs/apache-airflow/core-concepts/auth-manager.rst
+++ b/docs/apache-airflow/core-concepts/auth-manager.rst
@@ -161,7 +161,7 @@ Auth managers may vend CLI commands which will be included in the ``airflow`` co
 Rest API
 ^^^^^^^^
 
-Auth managers may vend Rest API endpoints which will be included in the :doc:`/stable-rest-api-ref` by implementing the ``get_api_endpoints`` method. The endpoints can be used to manage resources such as users, groups, roles (if any) handled by your auth manager. Endpoints are only vended for the currently configured auth manager.
+Auth managers may vend Rest API endpoints which will be included in the :doc:`/stable-rest-api-ref` by implementing the ``set_api_endpoints`` method. The endpoints can be used to manage resources such as users, groups, roles (if any) handled by your auth manager. Endpoints are only vended for the currently configured auth manager.
 
 Next Steps
 ^^^^^^^^^^

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -121,8 +121,8 @@ class TestBaseAuthManager:
     def test_get_cli_commands_return_empty_list(self, auth_manager):
         assert auth_manager.get_cli_commands() == []
 
-    def test_get_api_endpoints_return_none(self, auth_manager):
-        assert auth_manager.get_api_endpoints() is None
+    def test_set_api_endpoints_return_none(self, auth_manager):
+        assert auth_manager.set_api_endpoints() is None
 
     def test_get_user_name(self, auth_manager):
         user = Mock()


### PR DESCRIPTION
### Problem Definiton

Ref: [Github Pull Request #36052 VladaZakharova commented on Jan 18](https://github.com/apache/airflow/pull/36052#issuecomment-1898612794)

In the `init_api_auth_provider` method, we update the base path as follows:
```
def init_api_auth_provider(connexion_app: connexion.FlaskApp):
    """Initialize the API offered by the auth manager."""
    auth_mgr = get_auth_manager()
    blueprint = auth_mgr.get_api_endpoints(connexion_app)
    if blueprint:
        base_paths.append(blueprint.url_prefix if blueprint.url_prefix else "")
        flask_app = connexion_app.app
        flask_app.extensions["csrf"].exempt(blueprint)

```
However, the `blueprint` object obtained from `auth_mgr.get_api_endpoints(connexion_app)` will always be `None` if we are using **ConnexionV3**.

### Proposed solution
Ref [vincbeck commented on Jan 18](https://github.com/apache/airflow/pull/36052#issuecomment-1898786641)

- Rename `get_api_endpoints` to `set_api_endpoints`. The return type should be updated to `None`. Documentation should be updated as well to something like "Set API endpoint(s) definition for the auth manager.". This is a breaking change but nobody uses this interface yet, so it is a good time to do it.
- This piece of code `flask_app.extensions["csrf"].exempt(blueprint)` should be moved in the `set_api_endpoints` method using `appbuilder.app.extensions["csrf"].exempt(api.blueprint)`

### How to test
- **Run client tests** `python ./clients/python/test_python_client.py`
