### PR TITLE
Fix test_user_endpoint.py

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -203,7 +203,7 @@ class _LazyResolver(Resolver):
         return _LazyResolution(self.resolve_function_from_operation_id, operation_id)
 
 
-base_paths: list[str] = []  # contains the list of base paths that have api endpoints
+base_paths: list[str] = ["/auth/fab/v1"]  # contains the list of base paths that have api endpoints
 
 
 def init_api_error_handlers(connexion_app: connexion.FlaskApp) -> None:

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -338,6 +338,7 @@ def _delete_user(**filters):
         user = session.query(User).filter_by(**filters).first()
         if user is None:
             return
+        session.refresh(user)
         user.roles = []
         session.delete(user)
 

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -201,8 +201,8 @@ class TestGetUser(TestUserEndpoint):
         assert {
             "detail": "The User with username `invalid-user` was not found",
             "status": 404,
-            "title": "User not found",
-            "type": EXCEPTIONS_LINK_MAP[404],
+            "title": "Not Found",
+            "type": "about:blank",
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):


### PR DESCRIPTION
## Updates 
- Add session.refresh(user) to avoid StaleDataError 

## What I found about "coroutine" object is not callable error
![Screenshot from 2024-03-20 13-44-19](https://github.com/sudiptob2/airflow/assets/73622805/aef0b488-3151-4913-9a8e-0c64352f6d98)

- It happens with the endpoint which returns 404(Not Found) 
- Error comes from _handle_api_not_found from `airflow/www/extensions/init_views.py` and Starlette [code](https://github.com/encode/starlette/blob/554f368809e0d891a699667faf0cfbb20057eeb2/starlette/middleware/errors.py#L180)
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
