### PR TITLE
Fix test_auth.py

### DIFF
--- a/tests/api_connexion/conftest.py
+++ b/tests/api_connexion/conftest.py
@@ -33,6 +33,7 @@ def minimal_app_for_api():
             "init_appbuilder",
             "init_api_experimental_auth",
             "init_api_connexion",
+            "init_jinja_globals",
             "init_api_error_handlers",
             "init_airflow_session_interface",
             "init_appbuilder_views",

--- a/tests/api_connexion/test_auth.py
+++ b/tests/api_connexion/test_auth.py
@@ -150,7 +150,7 @@ class TestSessionAuth(BaseTestAuth):
         admin_user = client_with_login(self.connexion_app, username="test", password="test")
         response = admin_user.get("/api/v1/pools")
         assert response.status_code == 200
-        assert response.json == {
+        assert response.json() == {
             "pools": [
                 {
                     "name": "default_pool",

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -23,13 +23,13 @@ from unittest import mock
 from airflow.models import Log
 
 
-def client_with_login(app, expected_response_code=302, **kwargs):
+def client_with_login(app, expected_path=b"/home", **kwargs):
     patch_path = "airflow.providers.fab.auth_manager.security_manager.override.check_password_hash"
     with mock.patch(patch_path) as check_password_hash:
         check_password_hash.return_value = True
         client = app.test_client()
         resp = client.post("/login/", data=kwargs)
-        assert resp.status_code == expected_response_code
+        assert resp.url.raw_path == expected_path
     return client
 
 


### PR DESCRIPTION
## Updates 
> To avoid Error on "state_color_mapping" is undefined error

I included `init_jinja_gloabals` in the minimal_app_for_api. 
> Assertion Error 200 == 302 on client_with_login in tests/test_utils/www.py

It seems the responses to TestClient requests are after a user gets transferred, that is why we get the status code 200 instead of 302. We can use the path(`resp.url.raw_path==b"/home"`) to check if the redirection works instead of status code. 


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
