### PR TITLE
Fixed test_dag_endpoint.py

### DIFF
--- a/newsfragments/37638.significant.rst
+++ b/newsfragments/37638.significant.rst
@@ -1,0 +1,4 @@
+Replaced test_should_respond_400_on_invalid_request with test_ignore_read_only_fields in the test_dag_endpoint.py.
+
+Connexion V3 request body validator doesn't raise the read-only property error and just ignore the read-only field.
+You can find the detail about the change `here <https://github.com/spec-first/connexion/pull/1655>`_

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -377,16 +377,14 @@ class TestGetDagDetails(TestDagEndpoint):
             "timetable_description": None,
             "timezone": UTC_JSON_REPR,
         }
-        assert response.json == expected
+        assert response.json() == expected
 
     def test_should_respond_200_with_dataset_expression(self, url_safe_serializer):
         self._create_dag_model_for_details_endpoint_with_dataset_expression(self.dag_id)
         current_file_token = url_safe_serializer.dumps("/tmp/dag.py")
-        response = self.client.get(
-            f"/api/v1/dags/{self.dag_id}/details", environ_overrides={"REMOTE_USER": "test"}
-        )
+        response = self.client.get(f"/api/v1/dags/{self.dag_id}/details", headers={"REMOTE_USER": "test"})
         assert response.status_code == 200
-        last_parsed = response.json["last_parsed"]
+        last_parsed = response.json()["last_parsed"]
         expected = {
             "catchup": True,
             "concurrency": 16,
@@ -1306,9 +1304,9 @@ class TestPatchDag(TestDagEndpoint):
         assert response.status_code == 200
         _check_last_log(session, dag_id="TEST_DAG_1", event="api.patch_dag", execution_date=None)
 
-    def test_should_respond_400_on_invalid_request(self):
+    def test_ignore_read_only_fields(self):
         patch_body = {
-            "is_paused": True,
+            "is_paused": False,
             "schedule_interval": {
                 "__type": "CronExpression",
                 "value": "1 1 * * *",
@@ -1316,16 +1314,11 @@ class TestPatchDag(TestDagEndpoint):
         }
         dag_model = self._create_dag_model()
         response = self.client.patch(
-            f"/api/v1/dags/{dag_model.dag_id}",
-            json=patch_body,
+            f"/api/v1/dags/{dag_model.dag_id}", json=patch_body, headers={"REMOTE_USER": "test"}
         )
-        assert response.status_code == 400
-        assert response.json() == {
-            "detail": "Property is read-only - 'schedule_interval'",
-            "status": 400,
-            "title": "Bad Request",
-            "type": EXCEPTIONS_LINK_MAP[400],
-        }
+        assert response.status_code == 200
+        assert response.json()["is_paused"] is False
+        assert response.json()["schedule_interval"] == {"__type": "CronExpression", "value": "2 2 * * *"}
 
     def test_validation_error_raises_400(self):
         patch_body = {


### PR DESCRIPTION
## Updates 
- Fixed minor issues
- Replaced test_should_respond_400_on_invalid_request with test_ignore_read_only_fields in the test_dag_endpoint.py.
- Added siginificant.rst

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
