### PR TITLE
Fix error handling for api connexion test

### DIFF
--- a/tests/api_connexion/test_error_handling.py
+++ b/tests/api_connexion/test_error_handling.py
@@ -31,8 +31,8 @@ def test_incorrect_endpoint_should_return_json(minimal_app_for_api):
 
     # Then we have parsable JSON as output
 
-    assert "Not Found" == resp.json["title"]
-    assert 404 == resp.json["status"]
+    assert "Not Found" == resp.json()["title"]
+    assert 404 == resp.json()["status"]
     assert 404 == resp.status_code
 
 
@@ -45,8 +45,7 @@ def test_incorrect_endpoint_should_return_html(minimal_app_for_api):
 
     # Then we do not have JSON as response, rather standard HTML
 
-    assert resp.json is None
-    assert resp.mimetype == "text/html"
+    assert resp.headers["content-type"].startswith("text/html")
     assert resp.status_code == 404
 
 
@@ -60,8 +59,8 @@ def test_incorrect_method_should_return_json(minimal_app_for_api):
 
     # Then we have parsable JSON as output
 
-    assert "Method Not Allowed" == resp.json["title"]
-    assert 405 == resp.json["status"]
+    assert "Method Not Allowed" == resp.json()["title"]
+    assert 405 == resp.json()["status"]
     assert 405 == resp.status_code
 
 
@@ -74,6 +73,5 @@ def test_incorrect_method_should_return_html(minimal_app_for_api):
 
     # Then we do not have JSON as response, rather standard HTML
 
-    assert resp.json is None
-    assert resp.mimetype == "text/html"
+    assert resp.headers["content-type"].startswith("text/html")
     assert resp.status_code == 405


### PR DESCRIPTION
Example fixes to fix tests testing error handling

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
