### PR TITLE
Reverted error messages

### DIFF
--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -93,8 +93,8 @@ class TestDeleteConnection(TestConnectionEndpoint):
         assert response.json() == {
             "detail": "The Connection with connection_id: `test-connection` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Connection not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_should_raises_401_unauthenticated(self):
@@ -159,8 +159,8 @@ class TestGetConnection(TestConnectionEndpoint):
         assert {
             "detail": "The Connection with connection_id: `invalid-connection` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Connection not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):
@@ -503,8 +503,8 @@ class TestPatchConnection(TestConnectionEndpoint):
         assert {
             "detail": "The Connection with connection_id: `test-connection-id` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Connection not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -684,8 +684,8 @@ class TestGetDagDetails(TestDagEndpoint):
         assert response.json() == {
             "detail": "The DAG with dag_id: non_existing_dag_id was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "DAG not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     @pytest.mark.parametrize(
@@ -1349,8 +1349,8 @@ class TestPatchDag(TestDagEndpoint):
         assert response.json() == {
             "detail": None,
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Dag with id: 'non_existing_dag' not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_should_respond_404(self):
@@ -2293,8 +2293,8 @@ class TestDeleteDagEndpoint(TestDagEndpoint):
         assert response.json() == {
             "detail": None,
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Dag with id: 'TEST_DAG_1' not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_raises_when_task_instances_of_dag_is_still_running(self, dag_maker, session):

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -196,7 +196,7 @@ class TestDeleteDagRun(TestDagRunEndpoint):
             "detail": "DAGRun with DAG ID: 'INVALID_DAG_RUN' and DagRun ID: 'INVALID_DAG_RUN' not found",
             "status": 404,
             "title": "Not Found",
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -261,8 +261,8 @@ class TestGetDagRun(TestDagRunEndpoint):
         expected_resp = {
             "detail": "DAGRun with DAG ID: 'invalid-id' and DagRun ID: 'invalid-id' not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "DAGRun not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
         assert expected_resp == response.json()
 
@@ -1446,8 +1446,8 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert {
             "detail": "DAG with dag_id: 'TEST_DAG_ID' not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "DAG not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     @pytest.mark.parametrize(
@@ -1892,8 +1892,8 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         expected_resp = {
             "detail": "DAGRun with DAG ID: 'invalid-id' and DagRun ID: 'invalid-id' not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "DAGRun not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
         assert expected_resp == response.json()
 

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -23,6 +23,7 @@ from unittest.mock import ANY
 import pytest
 import time_machine
 
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import DagModel
 from airflow.models.dagrun import DagRun
 from airflow.models.dataset import (
@@ -134,7 +135,7 @@ class TestGetDatasetEndpoint(TestDatasetEndpoint):
             "detail": "The Dataset with uri: `s3://bucket/key` was not found",
             "status": 404,
             "title": "Not Found",
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -791,8 +792,8 @@ class TestGetDagDatasetQueuedEvent(TestQueuedEventEndpoint):
         assert {
             "detail": "Queue event with dag_id: `not_exists` and dataset uri: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -853,8 +854,8 @@ class TestDeleteDagDatasetQueuedEvent(TestDatasetEndpoint):
         assert {
             "detail": "Queue event with dag_id: `not_exists` and dataset uri: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -910,8 +911,8 @@ class TestGetDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         assert {
             "detail": "Queue event with dag_id: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):
@@ -945,8 +946,8 @@ class TestDeleteDagDatasetQueuedEvents(TestDatasetEndpoint):
         assert {
             "detail": "Queue event with dag_id: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):
@@ -1005,8 +1006,8 @@ class TestGetDatasetQueuedEvents(TestQueuedEventEndpoint):
         assert {
             "detail": "Queue event with dataset uri: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):
@@ -1057,8 +1058,8 @@ class TestDeleteDatasetQueuedEvents(TestQueuedEventEndpoint):
         assert {
             "detail": "Queue event with dataset uri: `not_exists` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Queue event not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import Log
 from airflow.security import permissions
 from airflow.utils import timezone
@@ -132,8 +133,8 @@ class TestGetEventLog(TestEventLogEndpoint):
         assert {
             "detail": None,
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Event Log not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, log_model):

--- a/tests/api_connexion/endpoints/test_extra_link_endpoint.py
+++ b/tests/api_connexion/endpoints/test_extra_link_endpoint.py
@@ -21,6 +21,7 @@ from urllib.parse import quote_plus
 
 import pytest
 
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models.baseoperatorlink import BaseOperatorLink
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
@@ -104,19 +105,19 @@ class TestGetExtraLinks:
         [
             pytest.param(
                 "/api/v1/dags/INVALID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_SINGLE_QUERY/links",
-                "Not Found",
+                "DAG not found",
                 'DAG with ID = "INVALID" not found',
                 id="missing_dag",
             ),
             pytest.param(
                 "/api/v1/dags/TEST_DAG_ID/dagRuns/INVALID/taskInstances/TEST_SINGLE_QUERY/links",
-                "Not Found",
+                "DAG Run not found",
                 'DAG Run with ID = "INVALID" not found',
                 id="missing_dag_run",
             ),
             pytest.param(
                 "/api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/INVALID/links",
-                "Not Found",
+                "Task not found",
                 'Task with ID = "INVALID" not found',
                 id="missing_task",
             ),
@@ -130,7 +131,7 @@ class TestGetExtraLinks:
             "detail": expected_detail,
             "status": 404,
             "title": expected_title,
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raise_403_forbidden(self):

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 
 import pytest
 
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models.dag import DagModel
 from airflow.models.errors import ImportError
 from airflow.security import permissions
@@ -120,8 +121,8 @@ class TestGetImportErrorEndpoint(TestBaseImportError):
         assert {
             "detail": "The ImportError with import_error_id: `2` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Import error not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -260,8 +260,8 @@ class TestGetLog:
         assert response.json() == {
             "detail": None,
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "TaskInstance not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_get_logs_with_metadata_as_download_large_file(self):
@@ -325,8 +325,8 @@ class TestGetLog:
         assert response.json() == {
             "detail": None,
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "TaskInstance not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_should_raises_401_unauthenticated(self):
@@ -365,7 +365,7 @@ class TestGetLog:
             headers={"Accept": "text/plain", "REMOTE_USER": "test"},
         )
         assert response.status_code == 404
-        assert response.json()["title"] == "Not Found"
+        assert response.json()["title"] == "TaskInstance not found"
 
     def test_should_raise_404_when_filtering_on_map_index_for_unmapped_task(self):
         key = self.flask_app.config["SECRET_KEY"]
@@ -378,4 +378,4 @@ class TestGetLog:
             headers={"Accept": "text/plain", "REMOTE_USER": "test"},
         )
         assert response.status_code == 404
-        assert response.json()["title"] == "Not Found"
+        assert response.json()["title"] == "TaskInstance not found"

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -23,6 +23,7 @@ import urllib
 
 import pytest
 
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
@@ -204,7 +205,7 @@ class TestNonExistent(TestMappedTaskInstanceEndpoint):
             headers={"REMOTE_USER": "test"},
         )
         assert response.status_code == 404
-        assert response.json()["title"] == "Not Found"
+        assert response.json()["title"] == "DAG mapped_tis not found"
 
 
 class TestGetMappedTaskInstance(TestMappedTaskInstanceEndpoint):
@@ -268,8 +269,8 @@ class TestGetMappedTaskInstance(TestMappedTaskInstanceEndpoint):
         assert response.json() == {
             "detail": "Task instance is mapped, add the map_index value to the URL",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Task instance not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
     def test_one_mapped_task_works(self, one_task_with_single_mapped_ti):
@@ -291,8 +292,8 @@ class TestGetMappedTaskInstance(TestMappedTaskInstanceEndpoint):
         assert response.json() == {
             "detail": "Task instance is mapped, add the map_index value to the URL",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "Task instance not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         }
 
 
@@ -469,4 +470,4 @@ class TestGetMappedTaskInstances(TestMappedTaskInstanceEndpoint):
             headers={"REMOTE_USER": "test"},
         )
         assert response.status_code == 404
-        assert response.json()["title"] == "Not Found"
+        assert response.json()["title"] == "Task id nonexistent_task not found"

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -245,7 +245,7 @@ class TestGetPool(TestBasePoolEndpoints):
             "detail": "Pool with name:'invalid_pool' not found",
             "status": 404,
             "title": "Not Found",
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):
@@ -275,7 +275,7 @@ class TestDeletePool(TestBasePoolEndpoints):
             "detail": "Pool with name:'invalid_pool' not found",
             "status": 404,
             "title": "Not Found",
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -452,7 +452,7 @@ class TestPatchPool(TestBasePoolEndpoints):
             "detail": "Pool with name:'test_pool' not found",
             "status": 404,
             "title": "Not Found",
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self, session):

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -285,9 +285,9 @@ class TestPatchVariable(TestVariableEndpoint):
         )
         assert response.status_code == 404
         assert response.json() == {
-            "title": "Not Found",
+            "title": "Variable not ound",
             "status": 404,
-            "type": "about:blank",
+            "type": EXCEPTIONS_LINK_MAP[404],
             "detail": "Variable does not exist",
         }
         Variable.set("var1", "foo")

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -201,8 +201,8 @@ class TestGetUser(TestUserEndpoint):
         assert {
             "detail": "The User with username `invalid-user` was not found",
             "status": 404,
-            "title": "Not Found",
-            "type": "about:blank",
+            "title": "User not found",
+            "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
     def test_should_raises_401_unauthenticated(self):


### PR DESCRIPTION
## Updates 
- Reverted error messages as the Error Handler was updated.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
