### PR TITLE
Fixed test_health_endpoint.py

### DIFF
--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -54,7 +54,8 @@ class TestGetHealth(TestHealthTestBase):
         SchedulerJobRunner(job=job)
         session.add(job)
         session.commit()
-        resp_json = self.client.get("/api/v1/health").json
+        session.close()
+        resp_json = self.client.get("/api/v1/health").json()
         assert "healthy" == resp_json["metadatabase"]["status"]
         assert "healthy" == resp_json["scheduler"]["status"]
         assert (
@@ -69,7 +70,8 @@ class TestGetHealth(TestHealthTestBase):
         SchedulerJobRunner(job=job)
         session.add(job)
         session.commit()
-        resp_json = self.client.get("/api/v1/health").json
+        session.close()
+        resp_json = self.client.get("/api/v1/health").json()
         assert "healthy" == resp_json["metadatabase"]["status"]
         assert "unhealthy" == resp_json["scheduler"]["status"]
         assert (
@@ -78,7 +80,7 @@ class TestGetHealth(TestHealthTestBase):
         )
 
     def test_unhealthy_scheduler_no_job(self):
-        resp_json = self.client.get("/api/v1/health").json
+        resp_json = self.client.get("/api/v1/health").json()
         assert "healthy" == resp_json["metadatabase"]["status"]
         assert "unhealthy" == resp_json["scheduler"]["status"]
         assert resp_json["scheduler"]["latest_scheduler_heartbeat"] is None
@@ -86,6 +88,6 @@ class TestGetHealth(TestHealthTestBase):
     @mock.patch.object(SchedulerJobRunner, "most_recent_job")
     def test_unhealthy_metadatabase_status(self, most_recent_job_mock):
         most_recent_job_mock.side_effect = Exception
-        resp_json = self.client.get("/api/v1/health").json
+        resp_json = self.client.get("/api/v1/health").json()
         assert "unhealthy" == resp_json["metadatabase"]["status"]
         assert resp_json["scheduler"]["latest_scheduler_heartbeat"] is None


### PR DESCRIPTION
## Updates 
- Added session.close()
- Used json() instead of json
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
