### PR TITLE
Fixed test_version_endpoint.py and test_xcom_endpoint.py

### DIFF
--- a/tests/api_connexion/endpoints/test_version_endpoint.py
+++ b/tests/api_connexion/endpoints/test_version_endpoint.py
@@ -40,5 +40,5 @@ class TestGetHealthTest:
         response = self.client.get("/api/v1/version")
 
         assert 200 == response.status_code
-        assert {"git_version": "GIT_COMMIT", "version": "MOCK_VERSION"} == response.json
+        assert {"git_version": "GIT_COMMIT", "version": "MOCK_VERSION"} == response.json()
         mock_get_airflow_get_commit.assert_called_once_with()

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -161,7 +161,7 @@ class TestGetXComEntry(TestXComEndpoint):
             headers={"REMOTE_USER": "test"},
         )
         assert 404 == response.status_code
-        assert response.json()["title"] == "Not Found"
+        assert response.json()["title"] == "XCom entry not found"
 
     def test_should_raises_401_unauthenticated(self):
         dag_id = "test-dag-id"


### PR DESCRIPTION
## Updates 
- Reverted error message
- Replaced json with json()
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
