### PR TITLE
Fixed test_rpc_api_endpoint.py

### DIFF
--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -123,9 +123,9 @@ class TestRpcApiEndpoint:
         )
         assert response.status_code == 200
         if method_result:
-            response_data = BaseSerialization.deserialize(json.loads(response.data), use_pydantic_models=True)
+            response_data = BaseSerialization.deserialize(json.loads(response.text), use_pydantic_models=True)
         else:
-            response_data = response.data
+            response_data = response.text
 
         assert result_cmp_func(response_data, method_result)
 
@@ -139,7 +139,7 @@ class TestRpcApiEndpoint:
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)
         )
         assert response.status_code == 500
-        assert response.data, b"Error executing method: test_method."
+        assert response.text, b"Error executing method: test_method."
         mock_test_method.assert_called_once()
 
     def test_unknown_method(self):
@@ -149,7 +149,7 @@ class TestRpcApiEndpoint:
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)
         )
         assert response.status_code == 400
-        assert response.data == b"Unrecognized method: i-bet-it-does-not-exist."
+        assert response.text == "Unrecognized method: i-bet-it-does-not-exist."
         mock_test_method.assert_not_called()
 
     def test_invalid_jsonrpc(self):
@@ -159,5 +159,5 @@ class TestRpcApiEndpoint:
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)
         )
         assert response.status_code == 400
-        assert response.data == b"Expected jsonrpc 2.0 request."
+        assert response.text == "Expected jsonrpc 2.0 request."
         mock_test_method.assert_not_called()


### PR DESCRIPTION
## Updates 
- Replaced response.data with response.text. Updated string accordingly.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
