### PR TITLE
Fix most test_task_instance_endpoint tests

### DIFF
--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -266,6 +266,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         ti.triggerer_job = Job()
         TriggererJobRunner(job=ti.triggerer_job)
         ti.triggerer_job.state = "running"
+        session.merge(ti)
         session.commit()
         session.close()
         response = self.client.get(
@@ -1279,7 +1280,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         )
         assert response.status_code == 200
         mock_clearti.assert_called_once_with(
-            [], session, dag=self.flask_app.dag_bag.get_dag(dag_id), dag_run_state=State.QUEUED
+            [], mock.ANY, dag=self.flask_app.dag_bag.get_dag(dag_id), dag_run_state=State.QUEUED
         )
         _check_last_log(session, dag_id=dag_id, event="api.post_clear_task_instances", execution_date=None)
 
@@ -1747,7 +1748,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json()["title"] == "Dag is non-existent-dag not found"
+        assert response.json()["title"] == "Dag id non-existent-dag not found"
 
 
 class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
@@ -1797,7 +1798,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             state="failed",
             task_id="print_the_context",
             upstream=True,
-            session=session,
+            session=mock.ANY,
         )
 
     @mock.patch("airflow.models.dag.DAG.set_task_instance_state")
@@ -1846,7 +1847,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             state="failed",
             task_id="print_the_context",
             upstream=True,
-            session=session,
+            session=mock.ANY,
         )
 
     @pytest.mark.parametrize(
@@ -2097,7 +2098,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             map_indexes=[-1],
             state=NEW_STATE,
             commit=True,
-            session=session,
+            session=mock.ANY,
         )
         _check_last_log(
             session,


### PR DESCRIPTION
There were two reasons for the test failed:

* when the Job was added to task instance, the task instance was not merged in session, which means that commit did not store the added Job

* some of the tests were expecting a call with specific session and they failed because session was different. Replacing the session with mock.ANY tells pytest that this parameter can be anything - we will have different session when when the call will be made with ASGI/Starlette

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
