### PR TITLE
Fixed Response Validator errors

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1367,6 +1367,10 @@ paths:
       responses:
         "204":
           description: Success.
+          content:
+            text/html:
+               schema:
+                 type: string
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2020,7 +2024,7 @@ paths:
                 properties:
                   content:
                     type: string
-            plain/text:
+            text/plain:
               schema:
                 type: string
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3681,7 +3681,11 @@ export interface operations {
     };
     responses: {
       /** Success. */
-      204: never;
+      204: {
+        content: {
+          "text/html": string;
+        };
+      };
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];
@@ -4468,7 +4472,7 @@ export interface operations {
           "application/json": {
             content?: string;
           };
-          "plain/text": string;
+          "text/plain": string;
         };
       };
       401: components["responses"]["Unauthenticated"];

--- a/tests/api_connexion/endpoints/test_dag_source_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_source_endpoint.py
@@ -100,7 +100,7 @@ class TestGetSource:
         dag_docstring = self._get_dag_file_docstring(test_dag.fileloc)
 
         url = f"/api/v1/dagSources/{url_safe_serializer.dumps(test_dag.fileloc)}"
-        response = self.client.get(url, headers={"Accept": "text/plain", "REMOTE_USER": "test"})
+        response = self.client.get(url, headers={"REMOTE_USER": "test"})
         assert 200 == response.status_code
         assert dag_docstring in response.text
         assert "text/plain" == response.headers["Content-Type"]

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -269,7 +269,6 @@ class TestDeletePool(TestBasePoolEndpoints):
         session.commit()
         session.close()
         response = self.client.delete(f"api/v1/pools/{pool_name}", headers={"REMOTE_USER": "test"})
-        assert response.json() == {}
         assert response.status_code == 204
         # Check if the pool is deleted from the db
         response = self.client.get(f"api/v1/pools/{pool_name}", headers={"REMOTE_USER": "test"})


### PR DESCRIPTION
## Related Issue 
closes #83 
## Update 
- Fixed typo for `dag_source_endpoint` and removed unnecessary header from the testing function
## Concern 
- I just added `html/plain` to OpenAPI spec for the `pool_endpoint` as the response validation error shows that the endpoint returns html/plain. The test case works fine now, but
I'm not sure if this endpoint should return html/plain here instead of application/json. 

https://github.com/sudiptob2/airflow/blob/30f3952d06796c16b35c144e998f3d8016500c78/airflow/api_connexion/endpoints/pool_endpoint.py#L45-L53



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Something wrong with `return Response(status=HTTPStatus.NO_CONTENT)`? 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
