### PR TITLE
Fix parameter validation

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -91,7 +91,7 @@ def get_connection(*, connection_id: str, session: Session = NEW_SESSION) -> API
 @provide_session
 def get_connections(
     *,
-    limit: int,
+    limit: int | None = None,
     offset: int = 0,
     order_by: str = "id",
     session: Session = NEW_SESSION,

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -94,7 +94,7 @@ def get_dag_details(
 @provide_session
 def get_dags(
     *,
-    limit: int,
+    limit: int | None = None,
     offset: int = 0,
     tags: Collection[str] | None = None,
     dag_id_pattern: str | None = None,

--- a/airflow/api_connexion/endpoints/dag_warning_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_warning_endpoint.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 @provide_session
 def get_dag_warnings(
     *,
-    limit: int,
+    limit: int | None = None,
     dag_id: str | None = None,
     warning_type: str | None = None,
     offset: int | None = None,

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -82,7 +82,7 @@ def get_dataset(*, uri: str, session: Session = NEW_SESSION) -> APIResponse:
 @provide_session
 def get_datasets(
     *,
-    limit: int,
+    limit: int | None = None,
     offset: int = 0,
     uri_pattern: str | None = None,
     dag_ids: str | None = None,
@@ -113,11 +113,11 @@ def get_datasets(
 
 
 @security.requires_access_dataset("GET")
-@provide_session
 @format_parameters({"limit": check_limit})
+@provide_session
 def get_dataset_events(
     *,
-    limit: int,
+    limit: int | None = None,
     offset: int = 0,
     order_by: str = "timestamp",
     dataset_id: int | None = None,

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -64,7 +64,7 @@ def get_event_logs(
     included_events: str | None = None,
     before: str | None = None,
     after: str | None = None,
-    limit: int,
+    limit: int | None = None,
     offset: int | None = None,
     order_by: str = "event_log_id",
     session: Session = NEW_SESSION,

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -77,7 +77,7 @@ def get_import_error(*, import_error_id: int, session: Session = NEW_SESSION) ->
 @provide_session
 def get_import_errors(
     *,
-    limit: int,
+    limit: int | None = None,
     offset: int | None = None,
     order_by: str = "import_error_id",
     session: Session = NEW_SESSION,

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -68,7 +68,7 @@ def get_pool(*, pool_name: str, session: Session = NEW_SESSION) -> APIResponse:
 @provide_session
 def get_pools(
     *,
-    limit: int,
+    limit: int | None = None,
     order_by: str = "id",
     offset: int | None = None,
     session: Session = NEW_SESSION,

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -296,7 +296,7 @@ def _apply_range_filter(query: Select, key: ClauseElement, value_range: tuple[T,
 @provide_session
 def get_task_instances(
     *,
-    limit: int,
+    limit: int | None = None,
     dag_id: str | None = None,
     dag_run_id: str | None = None,
     execution_date_gte: str | None = None,

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2106,29 +2106,6 @@ paths:
         "403":
           $ref: "#/components/responses/PermissionDenied"
 
-  /datasets/{uri}:
-    parameters:
-      - $ref: "#/components/parameters/DatasetURI"
-    get:
-      summary: Get a dataset
-      description: Get a dataset by uri.
-      x-openapi-router-controller: airflow.api_connexion.endpoints.dataset_endpoint
-      operationId: get_dataset
-      tags: [Dataset]
-      responses:
-        "200":
-          description: Success.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Dataset"
-        "401":
-          $ref: "#/components/responses/Unauthenticated"
-        "403":
-          $ref: "#/components/responses/PermissionDenied"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
   /datasets/events:
     get:
       summary: Get dataset events
@@ -2185,6 +2162,30 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /datasets/{uri}:
+    parameters:
+      - $ref: "#/components/parameters/DatasetURI"
+    get:
+      summary: Get a dataset
+      description: Get a dataset by uri.
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dataset_endpoint
+      operationId: get_dataset
+      tags: [Dataset]
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dataset"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 
   /config:
     get:

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -671,6 +671,12 @@ export interface paths {
   "/datasets": {
     get: operations["get_datasets"];
   };
+  "/datasets/events": {
+    /** Get dataset events */
+    get: operations["get_dataset_events"];
+    /** Create dataset event */
+    post: operations["create_dataset_event"];
+  };
   "/datasets/{uri}": {
     /** Get a dataset by uri. */
     get: operations["get_dataset"];
@@ -680,12 +686,6 @@ export interface paths {
         uri: components["parameters"]["DatasetURI"];
       };
     };
-  };
-  "/datasets/events": {
-    /** Get dataset events */
-    get: operations["get_dataset_events"];
-    /** Create dataset event */
-    post: operations["create_dataset_event"];
   };
   "/config": {
     get: operations["get_config"];
@@ -4543,26 +4543,6 @@ export interface operations {
       403: components["responses"]["PermissionDenied"];
     };
   };
-  /** Get a dataset by uri. */
-  get_dataset: {
-    parameters: {
-      path: {
-        /** The encoded Dataset URI */
-        uri: components["parameters"]["DatasetURI"];
-      };
-    };
-    responses: {
-      /** Success. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Dataset"];
-        };
-      };
-      401: components["responses"]["Unauthenticated"];
-      403: components["responses"]["PermissionDenied"];
-      404: components["responses"]["NotFound"];
-    };
-  };
   /** Get dataset events */
   get_dataset_events: {
     parameters: {
@@ -4620,6 +4600,26 @@ export interface operations {
       content: {
         "application/json": components["schemas"]["CreateDatasetEvent"];
       };
+    };
+  };
+  /** Get a dataset by uri. */
+  get_dataset: {
+    parameters: {
+      path: {
+        /** The encoded Dataset URI */
+        uri: components["parameters"]["DatasetURI"];
+      };
+    };
+    responses: {
+      /** Success. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Dataset"];
+        };
+      };
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
     };
   };
   get_config: {
@@ -5502,14 +5502,14 @@ export type GetDagWarningsVariables = CamelCasedPropertiesDeep<
 export type GetDatasetsVariables = CamelCasedPropertiesDeep<
   operations["get_datasets"]["parameters"]["query"]
 >;
-export type GetDatasetVariables = CamelCasedPropertiesDeep<
-  operations["get_dataset"]["parameters"]["path"]
->;
 export type GetDatasetEventsVariables = CamelCasedPropertiesDeep<
   operations["get_dataset_events"]["parameters"]["query"]
 >;
 export type CreateDatasetEventVariables = CamelCasedPropertiesDeep<
   operations["create_dataset_event"]["requestBody"]["content"]["application/json"]
+>;
+export type GetDatasetVariables = CamelCasedPropertiesDeep<
+  operations["get_dataset"]["parameters"]["path"]
 >;
 export type GetConfigVariables = CamelCasedPropertiesDeep<
   operations["get_config"]["parameters"]["query"]

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -134,7 +134,7 @@ class TestGetDatasetEndpoint(TestDatasetEndpoint):
         assert {
             "detail": "The Dataset with uri: `s3://bucket/key` was not found",
             "status": 404,
-            "title": "Not Found",
+            "title": "Dataset not found",
             "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json()
 
@@ -208,7 +208,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         )  # missing attr
 
         assert response.status_code == 400
-        msg = "Extra query parameter(s) order_by not in spec"
+        msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
         assert response.json()["detail"] == msg
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -621,7 +621,7 @@ class TestPostDatasetEvents(TestDatasetEndpoint):
         self._create_dataset(session)
         event_payload = {"dataset_uri": "s3://bucket/key", "extra": {"password": "bar"}}
         response = self.client.post(
-            "/api/v1/datasets/events", json=event_payload, environ_overrides={"REMOTE_USER": "test"}
+            "/api/v1/datasets/events", json=event_payload, headers={"REMOTE_USER": "test"}
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
* added default value for limit parameter across the board. Connexion 3 does not like if the parameter had no default and we had not provided one - even if our custom decorated was adding it. Adding default value and updating our decorator to treat None as `default` fixed a number of problems where limits were not passed

* swapped openapi specification for /datasets/{uri} and /dataset/events. Since `{uri}` was defined first, connection matched `events` with `{uri}` and chose parameter definitions from `{uri}` not events

* few other smaller fixes

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
