### PR TITLE
Fix most test_log_enpoint tests

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -107,7 +107,10 @@ def get_log(
         logs = logs[0] if task_try_number is not None else logs
         # we must have token here, so we can safely ignore it
         token = URLSafeSerializer(key).dumps(metadata)  # type: ignore[assignment]
-        return logs_schema.dump(LogResponseObject(continuation_token=token, content=logs))
+        return Response(
+            logs_schema.dumps(LogResponseObject(continuation_token=token, content=logs)),
+            headers={"Content-Type": "application/json"},
+        )
     # text/plain. Stream
     logs = task_log_reader.read_log_stream(ti, task_try_number, metadata)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1115,19 +1115,20 @@ def get_test_dag():
 
 @pytest.fixture
 def create_log_template(request):
-    from airflow import settings
     from airflow.models.tasklog import LogTemplate
 
-    session = settings.Session()
-
     def _create_log_template(filename_template, elasticsearch_id=""):
-        log_template = LogTemplate(filename=filename_template, elasticsearch_id=elasticsearch_id)
-        session.add(log_template)
-        session.commit()
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            log_template = LogTemplate(filename=filename_template, elasticsearch_id=elasticsearch_id)
+            session.add(log_template)
+            session.commit()
 
         def _delete_log_template():
-            session.delete(log_template)
-            session.commit()
+            with create_session() as session:
+                session.delete(log_template)
+                session.commit()
 
         request.addfinalizer(_delete_log_template)
 


### PR DESCRIPTION
The problem here was that some sessions should be committed/closed but also in order to run it standalone we wanted to create log templates in the database - as it relied implcitly on log templates created by other tests.

Also handling of the response without conteent type had to be fixed.

Remaining issue is 401 vs 403 forbidden returned. To be looked at later.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
