### PR TITLE
Fixed test_variable_endpoint.py

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1747,6 +1747,10 @@ paths:
       responses:
         "204":
           description: Success.
+          content:
+            text/html:
+               schema:
+                 type: string
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -4169,7 +4169,11 @@ export interface operations {
     };
     responses: {
       /** Success. */
-      204: never;
+      204: {
+        content: {
+          "text/html": string;
+        };
+      };
       400: components["responses"]["BadRequest"];
       401: components["responses"]["Unauthenticated"];
       403: components["responses"]["PermissionDenied"];

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -84,21 +84,19 @@ class TestVariableEndpoint:
 
 
 class TestDeleteVariable(TestVariableEndpoint):
-    ## TODO fix this test
-    # This test end up infinite loop(?) Cannot go to the next testing.
-    # def test_should_delete_variable(self, session):
-    #     Variable.set("delete_var1", 1)
-    #     # make sure variable is added
-    #     response = self.client.get("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
-    #     assert response.status_code == 200
+    def test_should_delete_variable(self, session):
+        Variable.set("delete_var1", 1)
+        # make sure variable is added
+        response = self.client.get("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
+        assert response.status_code == 200
 
-    #     response = self.client.delete("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
-    #     assert response.status_code == 204
+        response = self.client.delete("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
+        assert response.status_code == 204
 
-    #     # make sure variable is deleted
-    #     response = self.client.get("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
-    #     assert response.status_code == 404
-    #     _check_last_log(session, dag_id=None, event="variable.delete", execution_date=None)
+        # make sure variable is deleted
+        response = self.client.get("/api/v1/variables/delete_var1", headers={"REMOTE_USER": "test"})
+        assert response.status_code == 404
+        _check_last_log(session, dag_id=None, event="api.variable.delete", execution_date=None)
 
     def test_should_respond_404_if_key_does_not_exist(self):
         response = self.client.delete(
@@ -272,7 +270,7 @@ class TestPatchVariable(TestVariableEndpoint):
         )
         assert response.status_code == 200
         assert response.json() == {"key": "var1", "value": "foo", "description": "after_update"}
-        _check_last_log(session, dag_id=None, event="variable.edit", execution_date=None)
+        _check_last_log(session, dag_id=None, event="api.variable.edit", execution_date=None)
 
     def test_should_reject_invalid_update(self):
         response = self.client.patch(


### PR DESCRIPTION
## Update 
- Added `html/text` to the response to the Open API spec for the delete endpoint 
- Fixed the typo event argument value in the _check_last_log functions 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
