### PR TITLE
Fix test_views_paused

### DIFF
--- a/tests/www/views/test_views_paused.py
+++ b/tests/www/views/test_views_paused.py
@@ -34,17 +34,17 @@ def dags(create_dummy_dag):
     clear_db_dags()
 
 
-def test_logging_pause_dag(admin_client, dags, session):
+def test_logging_pause_dag(flask_admin_client, dags, session):
     dag, _ = dags
     # is_paused=false mean pause the dag
-    admin_client.post(f"/paused?is_paused=false&dag_id={dag.dag_id}", follow_redirects=True)
+    flask_admin_client.post(f"/paused?is_paused=false&dag_id={dag.dag_id}", follow_redirects=True)
     dag_query = session.query(Log).filter(Log.dag_id == dag.dag_id)
     assert '{"is_paused": true}' in dag_query.first().extra
 
 
-def test_logging_unpause_dag(admin_client, dags, session):
+def test_logging_unpause_dag(flask_admin_client, dags, session):
     _, paused_dag = dags
     # is_paused=true mean unpause the dag
-    admin_client.post(f"/paused?is_paused=true&dag_id={paused_dag.dag_id}", follow_redirects=True)
+    flask_admin_client.post(f"/paused?is_paused=true&dag_id={paused_dag.dag_id}", follow_redirects=True)
     dag_query = session.query(Log).filter(Log.dag_id == paused_dag.dag_id)
     assert '{"is_paused": false}' in dag_query.first().extra


### PR DESCRIPTION
Switching to flask client rather than starlette, helped to fix the issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
